### PR TITLE
platform: use 64 bit camera implementation

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -137,6 +137,8 @@ PRODUCT_PACKAGES += \
     gps.sm8150
 
 # CAMERA
+TARGET_USES_64BIT_CAMERA := true
+
 PRODUCT_PACKAGES += \
     camera.sm8150
 


### PR DESCRIPTION
The Kumano platform requires a 64 bit camera HAL.