### PR TITLE
[KUMANO] platform: Add QTI Haptics Vibrator HAL

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -166,3 +166,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 #WiFi MAC address path
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.wifi.addr_path=/data/vendor/wifi/wlan_mac.bin
+
+# QTI Haptics Vibrator
+PRODUCT_PACKAGES += \
+    vendor.qti.hardware.vibrator@1.2-service


### PR DESCRIPTION
This HAL is essential to get the QTI Haptics Vibrator working.

P.S.: https://portland.source.codeaurora.org/quic/la/platform/vendor/qcom-opensource/vibrator