### PR TITLE
genfs_contexts: Label npu as sysfs_msm_subsys.

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -13,6 +13,7 @@ genfscon sysfs /devices/platform/soc/8300000.qcom,turing                        
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/188101c.qcom,spss                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/5c00000.qcom,ssc                           u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/9800000.qcom,npu                           u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/ac4a000.qcom,cci                           u:object_r:sysfs_camera:s0
 genfscon sysfs /devices/platform/soc/ac4b000.qcom,cci                           u:object_r:sysfs_camera:s0


### PR DESCRIPTION
Various domains (which all have access to sysfs_msm_subsys) try to read
the npu subsystem:

libmdmdetect: Failed to open /sys/bus/msm_subsys/devices/subsys4/name: Permission denied
Diag_Lib:  Diag_LSM_Init: Failed to open handle to diag driver, error = 13
Diag_Lib:  Diag_LSM_Init: Failed to open handle to diag driver, error = 13
netmgrd : avc: denied { read } for name="name" scontext=u:r:netmgrd:s0 tcontext=u:object_r:sysfs:s0 tclass=file

Signed-off-by: MarijnS95 <marijns95@gmail.com>