### PR TITLE
[3/4] PlatformConfig: Enable FPC.

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -112,6 +112,4 @@ BOARD_BUILD_SYSTEM_ROOT_IMAGE := true
 
 BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 
-TARGET_DEVICE_NO_FPC := true
-
 include device/sony/common/CommonConfig.mk


### PR DESCRIPTION
The kernel and HAL gained support for the ET603 sensor found in Kumano
devices. Remove DEVICE_NO_FPC to compile this HAL and enable fingerprint
authentication.