### PR TITLE
[2/3] Kernel rework

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -113,4 +113,7 @@ TARGET_NO_RECOVERY := true
 BOARD_USES_RECOVERY_AS_BOOT := true
 BOARD_BUILD_SYSTEM_ROOT_IMAGE := true
 
+# DTBO partition definitions
+TARGET_NEEDS_DTBOIMAGE ?= true
+
 include device/sony/common/CommonConfig.mk

--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -102,9 +102,6 @@ NUM_FRAMEBUFFER_SURFACE_BUFFERS := 2
 # Lights HAL: Backlight
 TARGET_USES_SDE := true
 
-# Treble
-BOARD_VNDK_VERSION := current
-
 # Build a separate vendor.img
 TARGET_COPY_OUT_VENDOR := vendor
 BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := ext4
@@ -115,7 +112,5 @@ BOARD_AVB_ENABLE := true
 TARGET_NO_RECOVERY := true
 BOARD_USES_RECOVERY_AS_BOOT := true
 BOARD_BUILD_SYSTEM_ROOT_IMAGE := true
-
-BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 
 include device/sony/common/CommonConfig.mk

--- a/platform.mk
+++ b/platform.mk
@@ -17,7 +17,6 @@ PLATFORM_COMMON_PATH := device/sony/kumano
 
 SOMC_PLATFORM := kumano
 SOMC_KERNEL_VERSION := 4.14
-KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 
 SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 


### PR DESCRIPTION
See https://github.com/sonyxperiadev/device-sony-common/pull/669

## platform.mk: Move KERNEL_PATH to common
No need to set it in platform. Simplifies code for future refactors

## PlatformConfig: (Unconditionally) TARGET_NEEDS_DTBOIMAGE
Unify this into platform here from the individual tama device repos.

Don't guard TARGET_NEEDS_DTBOIMAGE by TARGET_COMPILE_WITH_MSM_KERNEL because it's unused if in-tree kernel compilation isn't being done.