### PR TITLE
[KUMANO] overlay: configure camera lift trigger sensor

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -22,4 +22,10 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- True if the device supports system navigation keys. -->
     <bool name="config_supportSystemNavigationKeys">true</bool>
+
+    <!-- The OEM specified sensor type for the lift trigger to launch the camera app. -->
+    <integer name="config_cameraLiftTriggerSensorType">66536</integer>
+    <!-- The OEM specified sensor string type for the gesture to launch camera app, this value
+        must match the value of config_cameraLiftTriggerSensorType in OEM's HAL -->
+    <string translatable="false" name="config_cameraLiftTriggerSensorStringType">com.sonymobile.sensor.camera_lift_trigger</string>
 </resources>


### PR DESCRIPTION
Kumano devices support this sensor and odm compatibility is introduced
in v5: when the device is locked, hold the phone up like you're about to
take a picture and the camera opens.