### PR TITLE
platform: Sync video props

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -270,8 +270,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Display - HDR/WCG
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.display.dataspace_saturation_matrix=1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0 \
-    ro.surface_flinger.has_wide_color_display=true \
     ro.surface_flinger.has_HDR_display=true \
+    ro.surface_flinger.has_wide_color_display=true \
+    ro.surface_flinger.max_frame_buffer_acquired_buffers=2 \
     ro.surface_flinger.use_color_management=true \
     ro.surface_flinger.wcg_composition_dataspace=143261696
 


### PR DESCRIPTION
The ConfigStore HAL is being deprecated and will apparently be removed in R.

See https://github.com/sonyxperiadev/device-sony-common/pull/709 for a more in-depths explanation.

Translate the uppercase makevars that `surfaceflinger.mk` used to supply as cflags to configstore internals to sysprops.

`max_frame_buffer_acquired_buffers = NUM_FRAMEBUFFER_SURFACE_BUFFER`

Note: The uppercase vars must be kept because `hardware/qcom/display` still relies on them at build time.