### PR TITLE
[KUMANO] Add NFC eSE and UICC support

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -254,6 +254,11 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.qcom.bluetooth.soc=cherokee
 
+# NFC eSE Support
+PRODUCT_PACKAGES += \
+    SecureElement \
+    android.hardware.secure_element@1.1-service
+
 # Audio - Android System
 PRODUCT_PROPERTY_OVERRIDES += \
     aaudio.mmap_policy=2 \

--- a/platform.mk
+++ b/platform.mk
@@ -78,6 +78,11 @@ PRODUCT_COPY_FILES += \
      frameworks/native/data/etc/android.hardware.sensor.stepcounter.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.sensor.stepcounter.xml \
      frameworks/native/data/etc/android.hardware.sensor.stepdetector.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.sensor.stepdetector.xml
 
+# NFC eSE Permissions
+PRODUCT_COPY_FILES += \
+     frameworks/native/data/etc/android.hardware.nfc.uicc.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.nfc.uicc.xml \
+     frameworks/native/data/etc/android.hardware.nfc.ese.xml:$(TARGET_OUT_COPY_VENDOR)/etc/permissions/android.hardware.nfc.ese.xml
+
 # Audio
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/audio_tuning_mixer_tavil.txt:$(TARGET_COPY_OUT_VENDOR)/etc/audio_tuning_mixer_tavil.txt \


### PR DESCRIPTION
Add the full support for Secure Element (eSE and UICC) on SoMC Kumano platform,
as supported by the PN554/557 NFC chips.

This patchset is essential to support all features in Kumano NFC.