### PR TITLE
[KUMANO] platform: Add sound trigger configuration for SoMC SM8150 Kumano

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -85,6 +85,8 @@ PRODUCT_COPY_FILES += \
 
 # Audio
 PRODUCT_COPY_FILES += \
+    $(SONY_ROOT)/vendor/etc/sound_trigger_platform_info.xml:$(TARGET_COPY_OUT_VENDOR)/etc/sound_trigger_platform_info.xml \
+    $(SONY_ROOT)/vendor/etc/sound_trigger_mixer_paths_wcd9340.xml:$(TARGET_COPY_OUT_VENDOR)/etc/sound_trigger_mixer_paths_wcd9340.xml \
     $(SONY_ROOT)/vendor/etc/audio_tuning_mixer_tavil.txt:$(TARGET_COPY_OUT_VENDOR)/etc/audio_tuning_mixer_tavil.txt \
     $(SONY_ROOT)/vendor/etc/audio_platform_info.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_platform_info.xml \
     $(SONY_ROOT)/vendor/etc/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml \

--- a/rootdir/vendor/etc/sound_trigger_mixer_paths_wcd9340.xml
+++ b/rootdir/vendor/etc/sound_trigger_mixer_paths_wcd9340.xml
@@ -1,0 +1,395 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--- Copyright (c) 2014-2018, The Linux Foundation. All rights reserved.       -->
+<!---                                                                           -->
+<!--- Redistribution and use in source and binary forms, with or without        -->
+<!--- modification, are permitted provided that the following conditions are    -->
+<!--- met:                                                                      -->
+<!---     * Redistributions of source code must retain the above copyright      -->
+<!---       notice, this list of conditions and the following disclaimer.       -->
+<!---     * Redistributions in binary form must reproduce the above             -->
+<!---       copyright notice, this list of conditions and the following         -->
+<!---       disclaimer in the documentation and/or other materials provided     -->
+<!---       with the distribution.                                              -->
+<!---     * Neither the name of The Linux Foundation nor the names of its       -->
+<!---       contributors may be used to endorse or promote products derived     -->
+<!---       from this software without specific prior written permission.       -->
+<!---                                                                           -->
+<!--- THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED              -->
+<!--- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF      -->
+<!--- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT    -->
+<!--- ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS    -->
+<!--- BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR    -->
+<!--- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF      -->
+<!--- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR           -->
+<!--- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,     -->
+<!--- WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE      -->
+<!--- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN    -->
+<!--- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                             -->
+
+<mixer>
+    <!-- These are the initial mixer settings -->
+    <ctl name="LSM1 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM2 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM3 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM4 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM5 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM6 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM7 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM8 Mixer SLIMBUS_5_TX" value="0" />
+    <ctl name="LSM1 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM2 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM3 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM4 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM5 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM6 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM7 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM8 Mixer SLIMBUS_1_TX" value="0" />
+    <ctl name="LSM1 Port" value="None" />
+    <ctl name="LSM2 Port" value="None" />
+    <ctl name="LSM3 Port" value="None" />
+    <ctl name="LSM4 Port" value="None" />
+    <ctl name="LSM5 Port" value="None" />
+    <ctl name="LSM6 Port" value="None" />
+    <ctl name="LSM7 Port" value="None" />
+    <ctl name="LSM8 Port" value="None" />
+    <ctl name="SLIMBUS_5_TX LSM Function" value="None" />
+    <ctl name="SLIMBUS_1_TX LSM Function" value="None" />
+    <ctl name="MADONOFF Switch" value="0" />
+    <ctl name="MAD Input" value="DMIC0" />
+    <ctl name="MAD_SEL MUX" value="SPE" />
+    <ctl name="MAD_INP MUX" value="DEC1" />
+    <ctl name="MAD_CPE1 Switch" value="0" />
+    <ctl name="CDC_IF TX13 MUX" value="ZERO" />
+    <ctl name="MAD_BROADCAST Switch" value="0" />
+    <ctl name="TX13 INP MUX" value="CDC_DEC_5" />
+    <ctl name="AIF4_MAD Mixer SLIM TX12" value="0" />
+    <ctl name="AIF4_MAD Mixer SLIM TX13" value="0" />
+    <ctl name="CPE AFE MAD Enable" value="0"/>
+    <ctl name="CLK MODE" value="EXTERNAL" />
+    <ctl name="EC BUF MUX INP" value="ZERO" />
+    <ctl name="ADC MUX1" value="DMIC" />
+    <ctl name="DMIC MUX1" value="ZERO" />
+    <ctl name="AIF3_CAP Mixer SLIM TX3" value="0"/>
+    <ctl name="AIF3_CAP Mixer SLIM TX2" value="0" />
+    <ctl name="AIF3_CAP Mixer SLIM TX1" value="0" />
+    <ctl name="AIF3_CAP Mixer SLIM TX0" value="0"/>
+    <ctl name="CDC_IF TX0 MUX" value="ZERO" />
+    <ctl name="CDC_IF TX1 MUX" value="ZERO" />
+    <ctl name="CDC_IF TX2 MUX" value="ZERO" />
+    <ctl name="CDC_IF TX3 MUX" value="ZERO" />
+    <ctl name="ADC MUX0" value="AMIC" />
+    <ctl name="ADC MUX1" value="AMIC" />
+    <ctl name="ADC MUX2" value="AMIC" />
+    <ctl name="ADC MUX3" value="AMIC" />
+    <ctl name="DMIC MUX0" value="ZERO" />
+    <ctl name="DMIC MUX1" value="ZERO" />
+    <ctl name="DMIC MUX2" value="ZERO" />
+    <ctl name="DMIC MUX3" value="ZERO" />
+    <ctl name="IIR0 INP0 MUX" value="ZERO" />
+    <ctl name= "ADC MUX0" value="AMIC" />
+    <ctl name= "ADC MUX1" value="AMIC" />
+    <ctl name= "ADC MUX2" value="AMIC" />
+    <ctl name= "DMIC MUX0" value="ZERO" />
+    <ctl name= "DMIC MUX2" value="ZERO" />
+    <ctl name= "WDMA3 PORT0 MUX" value="RX_MIX_TX0" />
+    <ctl name= "WDMA3 PORT1 MUX" value="RX_MIX_TX1" />
+    <ctl name= "WDMA3 PORT2 MUX" value="RX_MIX_TX2" />
+    <ctl name= "WDMA3 CH0 MUX" value="PORT_0" />
+    <ctl name= "WDMA3 CH1 MUX" value="PORT_0" />
+    <ctl name= "WDMA3 CH2 MUX" value="PORT_0" />
+    <ctl name= "WDMA3_ON_OFF Switch" value="0" />
+    <ctl name="SLIM_1_TX Channels" value="One" />
+    <ctl name="AUDIO_REF_EC_UL1 MUX" value="None"/>
+    <ctl name="EC Reference Channels" value="Zero"/>
+    <ctl name="EC Reference Bit Format" value="0"/>
+    <ctl name="EC Reference SampleRate" value="0"/>
+
+    <path name="listen-voice-wakeup-1">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM1 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM1 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-2">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM2 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM2 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-3">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM3 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM3 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-4">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM4 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM4 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-5">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM5 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM5 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-6">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM6 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM6 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-7">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM7 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM7 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-8">
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+        <ctl name="LSM8 Port" value="SLIMBUS_5_TX" />
+        <ctl name="LSM8 Mixer SLIMBUS_5_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-1 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM1 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM1 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-2 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM2 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM2 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-3 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM3 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM3 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-4 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM4 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM4 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-5 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM5 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM5 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-6 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM6 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM6 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-7 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM7 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM7 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-voice-wakeup-8 preproc">
+        <ctl name="SLIMBUS_1_TX LSM Function" value="SWAUDIO" />
+        <ctl name="LSM8 Port" value="ADM_LSM_TX" />
+        <ctl name="LSM8 Mixer SLIMBUS_1_TX" value="1" />
+    </path>
+
+    <path name="listen-cpe-handset-mic">
+        <ctl name="MAD Input" value="DMIC0" />
+        <ctl name="MAD_SEL MUX" value="SPE" />
+        <ctl name="MAD_INP MUX" value="MAD" />
+        <ctl name="MAD_CPE1 Switch" value="1" />
+    </path>
+
+    <path name="listen-cpe-handset-dmic">
+        <ctl name="CLK MODE" value="INTERNAL" />
+        <ctl name= "ADC MUX0" value="DMIC" />
+        <ctl name= "DMIC MUX0" value="DMIC2" />
+        <ctl name= "DEC0 Volume" value="84" />
+        <ctl name= "ADC MUX1" value="DMIC" />
+        <ctl name= "DMIC MUX1" value="DMIC0" />
+        <ctl name= "DEC1 Volume" value="84" />
+        <ctl name= "WDMA3 PORT0 MUX" value="DEC0" />
+        <ctl name= "WDMA3 PORT1 MUX" value="DEC1" />
+        <ctl name= "WDMA3 CH0 MUX" value="PORT_0" />
+        <ctl name= "WDMA3 CH1 MUX" value="PORT_1" />
+        <ctl name= "WDMA3_ON_OFF Switch" value="1" />
+    </path>
+
+    <path name="listen-cpe-handset-tmic">
+        <ctl name="CLK MODE" value="INTERNAL" />
+        <ctl name= "ADC MUX0" value="DMIC" />
+        <ctl name= "DMIC MUX0" value="DMIC2" />
+        <ctl name= "DEC0 Volume" value="84" />
+        <ctl name= "ADC MUX1" value="DMIC" />
+        <ctl name= "DMIC MUX1" value="DMIC0" />
+        <ctl name= "DEC1 Volume" value="84" />
+        <ctl name= "ADC MUX2" value="DMIC" />
+        <ctl name= "DMIC MUX2" value="DMIC1" />
+        <ctl name= "DEC2 Volume" value="84" />
+        <ctl name= "WDMA3 PORT0 MUX" value="DEC0" />
+        <ctl name= "WDMA3 PORT1 MUX" value="DEC1" />
+        <ctl name= "WDMA3 PORT2 MUX" value="DEC2" />
+        <ctl name= "WDMA3 CH0 MUX" value="PORT_0" />
+        <ctl name= "WDMA3 CH1 MUX" value="PORT_1" />
+        <ctl name= "WDMA3 CH2 MUX" value="PORT_2" />
+        <ctl name= "WDMA3_ON_OFF Switch" value="1" />
+    </path>
+
+    <path name="listen-cpe-handset-qmic">
+        <ctl name="CLK MODE" value="INTERNAL" />
+        <ctl name= "ADC MUX0" value="DMIC" />
+        <ctl name= "DMIC MUX0" value="DMIC2" />
+        <ctl name= "DEC0 Volume" value="84" />
+        <ctl name= "ADC MUX1" value="DMIC" />
+        <ctl name= "DMIC MUX1" value="DMIC0" />
+        <ctl name= "DEC1 Volume" value="84" />
+        <ctl name= "ADC MUX2" value="DMIC" />
+        <ctl name= "DMIC MUX2" value="DMIC1" />
+        <ctl name= "DEC2 Volume" value="84" />
+        <ctl name= "ADC MUX3" value="DMIC" />
+        <ctl name= "DMIC MUX3" value="DMIC3" />
+        <ctl name= "DEC3 Volume" value="84" />
+        <ctl name= "WDMA3 PORT0 MUX" value="DEC0" />
+        <ctl name= "WDMA3 PORT1 MUX" value="DEC1" />
+        <ctl name= "WDMA3 PORT2 MUX" value="DEC2" />
+        <ctl name= "WDMA3 PORT3 MUX" value="DEC3" />
+        <ctl name= "WDMA3 CH0 MUX" value="PORT_0" />
+        <ctl name= "WDMA3 CH1 MUX" value="PORT_1" />
+        <ctl name= "WDMA3 CH2 MUX" value="PORT_2" />
+        <ctl name= "WDMA3 CH3 MUX" value="PORT_3" />
+        <ctl name= "WDMA3_ON_OFF Switch" value="1" />
+    </path>
+
+    <path name="listen-cpe-headset-mic">
+        <ctl name="MAD Input" value="ADC2" />
+        <ctl name="MAD_SEL MUX" value="SPE" />
+        <ctl name="MAD_INP MUX" value="MAD" />
+        <ctl name="MAD_CPE1 Switch" value="1" />
+    </path>
+
+    <path name="listen-cpe-handset-mic-ecpp">
+        <ctl name="CLK MODE" value="INTERNAL" />
+        <ctl name="EC BUF MUX INP" value="DEC1" />
+        <ctl name="ADC MUX1" value="DMIC" />
+        <ctl name="DMIC MUX1" value="DMIC2" />
+    </path>
+
+    <!-- path name used for low bandwidth FTRT codec interface -->
+    <path name="listen-cpe-handset-mic low-speed-intf">
+        <ctl name="MADONOFF Switch" value="1" />
+        <ctl name="AIF4_MAD Mixer SLIM TX12" value="1" />
+        <ctl name="MAD Input" value="DMIC2" />
+        <ctl name="CPE AFE MAD Enable" value="1"/>
+    </path>
+
+    <path name="listen-ape-handset-mic">
+        <ctl name="MAD Input" value="DMIC2" />
+        <ctl name="MAD_SEL MUX" value="MSM" />
+        <ctl name="MAD_INP MUX" value="MAD" />
+        <ctl name="MAD_BROADCAST Switch" value="1" />
+        <ctl name="CDC_IF TX13 MUX" value="MAD_BRDCST" />
+        <ctl name="AIF4_MAD Mixer SLIM TX13" value="1" />
+    </path>
+
+    <path name="listen-ape-headset-mic">
+        <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
+        <ctl name="SLIM_1_TX Channels" value="One" />
+        <ctl name="CDC_IF TX2 MUX" value="DEC2" />
+        <ctl name="ADC MUX2" value="AMIC" />
+        <ctl name="AMIC MUX2" value="ADC2" />
+        <ctl name="DEC2 Volume" value="84" />
+    </path>
+
+    <path name="listen-ape-handset-mic-preproc">
+        <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
+        <ctl name="SLIM_1_TX Channels" value="One" />
+        <ctl name="CDC_IF TX2 MUX" value="DEC2" />
+        <ctl name="ADC MUX2" value="DMIC" />
+        <ctl name="DMIC MUX2" value="DMIC0" />
+        <ctl name="IIR0 INP0 MUX" value="DEC2" />
+    </path>
+
+    <path name="listen-ape-handset-dmic">
+        <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
+        <ctl name="AIF3_CAP Mixer SLIM TX3" value="1" />
+        <ctl name="CDC_IF TX2 MUX" value="DEC2" />
+        <ctl name="ADC MUX2" value="DMIC" />
+        <ctl name="DMIC MUX2" value="DMIC1" />
+        <ctl name="CDC_IF TX3 MUX" value="DEC3" />
+        <ctl name="ADC MUX3" value="DMIC" />
+        <ctl name="DMIC MUX3" value="DMIC5" />
+        <ctl name="SLIM_1_TX Channels" value="Two" />
+    </path>
+
+    <path name="listen-ape-handset-tmic">
+        <ctl name="AIF3_CAP Mixer SLIM TX0" value="1" />
+        <ctl name="AIF3_CAP Mixer SLIM TX1" value="1" />
+        <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
+        <ctl name="SLIM_1_TX Channels" value="Three" />
+        <ctl name="CDC_IF TX0 MUX" value="DEC0" />
+        <ctl name="ADC MUX0" value="DMIC" />
+        <ctl name="DMIC MUX0" value="DMIC1" />
+        <ctl name="CDC_IF TX1 MUX" value="DEC1" />
+        <ctl name="ADC MUX1" value="DMIC" />
+        <ctl name="DMIC MUX1" value="DMIC5" />
+        <ctl name="CDC_IF TX2 MUX" value="DEC2" />
+        <ctl name="ADC MUX2" value="DMIC" />
+        <ctl name="DMIC MUX2" value="DMIC2" />
+    </path>
+
+    <path name="listen-ape-handset-qmic">
+        <ctl name="AIF3_CAP Mixer SLIM TX0" value="1" />
+        <ctl name="AIF3_CAP Mixer SLIM TX1" value="1" />
+        <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
+        <ctl name="AIF3_CAP Mixer SLIM TX3" value="1" />
+        <ctl name="SLIM_1_TX Channels" value="Four" />
+        <ctl name="CDC_IF TX0 MUX" value="DEC0" />
+        <ctl name="ADC MUX0" value="DMIC" />
+        <ctl name="DMIC MUX0" value="DMIC1" />
+        <ctl name="CDC_IF TX1 MUX" value="DEC1" />
+        <ctl name="ADC MUX1" value="DMIC" />
+        <ctl name="DMIC MUX1" value="DMIC5" />
+        <ctl name="CDC_IF TX2 MUX" value="DEC2" />
+        <ctl name="ADC MUX2" value="DMIC" />
+        <ctl name="DMIC MUX2" value="DMIC2" />
+        <ctl name="CDC_IF TX3 MUX" value="DEC3" />
+        <ctl name="ADC MUX3" value="DMIC" />
+        <ctl name="DMIC MUX3" value="DMIC0" />
+    </path>
+
+    <path name="echo-reference">
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_RX"/>
+        <ctl name="EC Reference Channels" value="Two"/>
+        <ctl name="EC Reference Bit Format" value="S16_LE"/>
+        <ctl name="EC Reference SampleRate" value="48000"/>
+    </path>
+
+    <path name="echo-reference line">
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_6_RX"/>
+        <ctl name="EC Reference Channels" value="Two"/>
+        <ctl name="EC Reference Bit Format" value="S16_LE"/>
+        <ctl name="EC Reference SampleRate" value="48000"/>
+    </path>
+
+    <path name="echo-reference headset">
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_6_RX"/>
+        <ctl name="EC Reference Channels" value="One"/>
+        <ctl name="EC Reference Bit Format" value="S16_LE"/>
+        <ctl name="EC Reference SampleRate" value="48000"/>
+    </path>
+
+    <path name="echo-reference a2dp">
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_7_RX"/>
+        <ctl name="EC Reference Channels" value="Two"/>
+        <ctl name="EC Reference Bit Format" value="S16_LE"/>
+        <ctl name="EC Reference SampleRate" value="48000"/>
+    </path>
+
+</mixer>

--- a/rootdir/vendor/etc/sound_trigger_platform_info.xml
+++ b/rootdir/vendor/etc/sound_trigger_platform_info.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--- Copyright (c) 2013-2018, The Linux Foundation. All rights reserved.       -->
+<!---                                                                           -->
+<!--- Redistribution and use in source and binary forms, with or without        -->
+<!--- modification, are permitted provided that the following conditions are    -->
+<!--- met:                                                                      -->
+<!---     * Redistributions of source code must retain the above copyright      -->
+<!---       notice, this list of conditions and the following disclaimer.       -->
+<!---     * Redistributions in binary form must reproduce the above             -->
+<!---       copyright notice, this list of conditions and the following         -->
+<!---       disclaimer in the documentation and/or other materials provided     -->
+<!---       with the distribution.                                              -->
+<!---     * Neither the name of The Linux Foundation nor the names of its       -->
+<!---       contributors may be used to endorse or promote products derived     -->
+<!---       from this software without specific prior written permission.       -->
+<!---                                                                           -->
+<!--- THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED              -->
+<!--- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF      -->
+<!--- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT    -->
+<!--- ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS    -->
+<!--- BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR    -->
+<!--- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF      -->
+<!--- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR           -->
+<!--- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,     -->
+<!--- WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE      -->
+<!--- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN    -->
+<!--- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                             -->
+<sound_trigger_platform_info>
+    <param version="0x0105" /> <!-- this must be the first param -->
+<!--- Version History:                                                          -->
+<!--- 0x0101: Legacy version.                                                   -->
+<!--- 0x0102: Includes acdb_ids param with the gcs_usecase tag. This matches    -->
+<!--- the gcs_usecase with the acdb device that uses it.                        -->
+<!--- 0x0103: app_type and in_channels added to <lsm usecase> and out_channels  -->
+<!--- added to <adm_config>                                                     -->
+<!--- 0x0104: instance id support for both WDSP<CPE> and ADSP lsm usecases      -->
+<!--- 0x0105: Select <lsm_usecase> based on capture device                      -->
+
+    <common_config>
+        <param implementer_version="0x0100" />
+        <param max_cpe_sessions="1" />
+        <param max_wdsp_sessions="2" />
+        <param max_ape_sessions="8" />
+        <param enable_failure_detection="false" />
+        <param support_device_switch="false" />
+        <!-- Transition will only occur if execution_type="DYNAMIC" -->
+        <param transit_to_adsp_on_playback="true" />
+        <param transit_to_adsp_on_battery_charging="false" />
+        <!-- Below backend params must match with port used in mixer path file -->
+        <!-- param used to configure backend sample rate, format and channels -->
+        <param backend_port_name="SLIM_1_TX" />
+        <!-- Param used to match and obtain device backend index -->
+        <param backend_dai_name="SLIMBUS_1_TX" />
+        <!-- Param used to indicate if SVA has dedicated SLIM ports -->
+        <param dedicated_sva_path="true" />
+    </common_config>
+    <acdb_ids>
+        <param DEVICE_HANDSET_MIC_APE="100" />
+        <param DEVICE_HANDSET_MIC_CPE="128" />
+        <param DEVICE_HANDSET_MIC_ECPP_CPE="128" />
+        <param DEVICE_HANDSET_TMIC_CPE="130" />
+        <param DEVICE_HANDSET_TMIC_APE="157" />
+        <param DEVICE_HANDSET_MIC_PP_APE="135" />
+        <param DEVICE_HANDSET_QMIC_APE="137" />
+        <param DEVICE_HEADSET_MIC_CPE="139" />
+        <param DEVICE_HEADSET_MIC_APE="141" />
+        <param DEVICE_HANDSET_DMIC_APE="149" />
+        <param DEVICE_HANDSET_DMIC_CPE="148" />
+    </acdb_ids>
+
+    <!-- Multiple sound_model_config tags can be listed, each with unique   -->
+    <!-- vendor_uuid. The below tag represents QTI SVA engine sound model   -->
+    <!-- configuration. ISV must use their own unique vendor_uuid.          -->
+
+    <!-- QTI SVA -->
+    <sound_model_config>
+        <param vendor_uuid="68ab2d40-e860-11e3-95ef-0002a5d5c51b" />
+        <param execution_type="DYNAMIC" /> <!-- value: "WDSP" "ADSP" "DYNAMIC" -->
+        <param library="libsmwrapper.so" />
+        <param max_cpe_phrases="6" />
+        <param max_cpe_users="3" />
+        <param max_ape_phrases="20" />
+        <param max_ape_users="10" />
+        <!-- Profile specific data which the algorithm can support -->
+        <param sample_rate="16000" />
+        <param bit_width="16" />
+        <param out_channels="1"/> <!-- Module output channels -->
+        <!-- wdsp_fluence_type: fluence disabled: "NONE" -->
+        <!-- fluence enabled: "FLUENCE_DMIC", "FLUENCE_TMIC", "FLUENCE_QMIC" -->
+        <param wdsp_fluence_type="NONE" />
+        <arm_ss_usecase>
+            <!-- Options are "KEYWORD_DETECTION", "USER_VERIFICATION", "CUSTOM_DETECTION"  -->
+            <param sm_detection_type= "KEYWORD_DETECTION" />
+            <param sm_id="0x2" />
+            <param module_lib="libcapiv2svacnn.so"/>
+            <param sample_rate="16000"/>
+            <param bit_wdith="16"/>
+            <param channel_count="1"/>
+        </arm_ss_usecase>
+        <arm_ss_usecase>
+            <param sm_detection_type= "USER_VERIFICATION" />
+            <param sm_id="0x4" />
+            <param module_lib="libcapiv2vop.so"/>
+            <param sample_rate="16000"/>
+            <param bit_wdith="16"/>
+            <param channel_count="1"/>
+        </arm_ss_usecase>
+        <gcs_usecase>
+            <param uid="0x1" />
+            <param acdb_devices="DEVICE_HANDSET_MIC_CPE, DEVICE_HANDSET_TMIC_CPE, DEVICE_HEADSET_MIC_CPE" />
+            <!-- module_id, instance_id, param_id -->
+            <param load_sound_model_ids="0x00012C0D, 0x2, 0x00012C14" />
+            <param confidence_levels_ids="0x00012C0D, 0x2, 0x00012C28" />
+            <param detection_event_ids="0x00012C0D, 0x2, 0x00012B05" />
+            <param read_cmd_ids="0x00020013, 0x2, 0x00020015" />
+            <param read_rsp_ids="0x00020013, 0x2, 0x00020016" />
+            <param custom_config_ids="0x00012C0D, 0x2, 0x00012C20" />
+            <param det_event_type_ids="0x00012C0D, 0x2, 0x00012C2A" />
+        </gcs_usecase>
+        <gcs_usecase>
+            <param uid="0x2" />
+            <param acdb_devices="DEVICE_HANDSET_MIC_CPE, DEVICE_HANDSET_TMIC_CPE, DEVICE_HEADSET_MIC_CPE" />
+            <param load_sound_model_ids="0x00012C0D, 0x3, 0x00012C14" />
+            <param confidence_levels_ids="0x00012C0D, 0x3, 0x00012C28" />
+            <param detection_event_ids="0x00012C0D, 0x3, 0x00012B05" />
+            <param read_cmd_ids="0x00020013, 0x3, 0x00020015" />
+            <param read_rsp_ids="0x00020013, 0x3, 0x00020016" />
+            <param custom_config_ids="0x00012C0D, 0x3, 0x00012C20" />
+            <param det_event_type_ids="0x00012C0D, 0x3, 0x00012C2A" />
+        </gcs_usecase>
+        <gcs_usecase>
+            <param uid="0x7" />
+            <param acdb_devices="DEVICE_HANDSET_DMIC_CPE" />
+            <param load_sound_model_ids="0x00012C0D, 0x7, 0x00012C14" />
+            <param confidence_levels_ids="0x00012C0D, 0x7, 0x00012C28" />
+            <param detection_event_ids="0x00012C0D, 0x7, 0x00012B05" />
+            <param read_cmd_ids="0x00020013, 0x7, 0x00020015" />
+            <param read_rsp_ids="0x00020013, 0x7, 0x00020016" />
+            <param custom_config_ids="0x00012C0D, 0x7, 0x00012C20" />
+            <param det_event_type_ids="0x00012C0D, 0x7, 0x00012C2A" />
+        </gcs_usecase>
+        <gcs_usecase>
+            <param uid="0x8" />
+            <param acdb_devices="DEVICE_HANDSET_DMIC_CPE" />
+            <param load_sound_model_ids="0x00012C0D, 0x8, 0x00012C14" />
+            <param confidence_levels_ids="0x00012C0D, 0x8, 0x00012C28" />
+            <param detection_event_ids="0x00012C0D, 0x8, 0x00012B05" />
+            <param read_cmd_ids="0x00020013, 0x8, 0x00020015" />
+            <param read_rsp_ids="0x00020013, 0x8, 0x00020016" />
+            <param custom_config_ids="0x00012C0D, 0x8, 0x00012C20" />
+            <param det_event_type_ids="0x00012C0D, 0x8, 0x00012C2A" />
+        </gcs_usecase>
+        <!-- Module and param ids with which the algorithm is integrated
+            in non-graphite firmware (note these must come after gcs params)
+            Extends flexibility to have different ids based on execution type.
+            valid execution_type values: "WDSP" "ADSP" -->
+        <lsm_usecase>
+            <param capture_device="HANDSET" />
+            <!-- adm_cfg_profile should match with the one defined under adm_config -->
+            <!-- Set it to NONE if LSM directly connects to AFE -->
+            <param adm_cfg_profile="FFECNS" />
+            <!-- fluence_type: "FLUENCE_MIC", "FLUENCE_DMIC", "FLUENCE_TMIC"   -->
+            <!-- "FLUENCE_QMIC". Param value is valid when adm_cfg_profile -->
+            <!-- is FFECNS -->
+            <param fluence_type="FLUENCE_MIC" />
+            <param execution_mode="ADSP" />
+            <param app_type="2" /> <!-- app type used in ACDB -->
+            <param in_channels="1"/> <!-- Module input channels -->
+            <param load_sound_model_ids="0x00012C1C, 0x0, 0x00012C14" />
+            <param unload_sound_model_ids="0x00012C1C, 0x0, 0x00012C15" />
+            <param confidence_levels_ids="0x00012C1C, 0x0, 0x00012C07" />
+            <param operation_mode_ids="0x00012C1C, 0x0, 0x00012C02" />
+            <param polling_enable_ids="0x00012C1C, 0x0, 0x00012C1B" />
+            <param custom_config_ids="0x00012C1C, 0x0, 0x00012C20" />
+            <param det_event_type_ids="0x00012C1C, 0x0, 0x00012C2C" />
+        </lsm_usecase>
+        <lsm_usecase>
+            <param capture_device="HEADSET" />
+            <param adm_cfg_profile="FFECNS" />
+            <param fluence_type="FLUENCE_MIC" />
+            <param execution_mode="ADSP" />
+            <param app_type="2" /> <!-- app type used in ACDB -->
+            <param in_channels="1"/> <!-- Module input channels -->
+            <param load_sound_model_ids="0x00012C1C, 0x0, 0x00012C14" />
+            <param unload_sound_model_ids="0x00012C1C, 0x0, 0x00012C15" />
+            <param confidence_levels_ids="0x00012C1C, 0x0, 0x00012C07" />
+            <param operation_mode_ids="0x00012C1C, 0x0, 0x00012C02" />
+            <param polling_enable_ids="0x00012C1C, 0x0, 0x00012C1B" />
+            <param custom_config_ids="0x00012C1C, 0x0, 0x00012C20" />
+            <param det_event_type_ids="0x00012C1C, 0x0, 0x00012C2C" />
+        </lsm_usecase>
+
+        <!-- format: "ADPCM_packet" or "PCM_packet" !-->
+        <!-- transfer_mode: "FTRT" or "RT" -->
+        <!--  kw_duration is in milli seconds. It is valid only for FTRT
+            transfer mode -->
+        <param capture_keyword="PCM_packet, RT, 2000" />
+        <param capture_keyword="PCM_packet, RT, 1000" />
+        <param client_capture_read_delay="2000" />
+    </sound_model_config>
+
+    <!-- QTI Music Detection !-->
+    <sound_model_config>
+        <param vendor_uuid="876c1b46-9d4d-40cc-a4fd-4d5ec7a80e47" />
+        <param execution_type="WDSP" /> <!-- value: "WDSP" "ADSP" "DYNAMIC" -->
+        <param library="libsmwrapper.so" />
+        <param max_cpe_phrases="1" />
+        <param max_cpe_users="1" />
+        <param max_ape_phrases="1" />
+        <param max_ape_users="1" />
+        <!-- Profile specific data which the algorithm can support -->
+        <param sample_rate="16000" />
+        <param bit_width="16" />
+        <param out_channels="1"/> <!-- Module output channels -->
+        <!-- wdsp_fluence_type: fluence disabled: "NONE" -->
+        <!-- fluence enabled: "FLUENCE_DMIC", "FLUENCE_TMIC", "FLUENCE_QMIC" -->
+        <param wdsp_fluence_type="NONE" />
+        <gcs_usecase>
+            <param uid="0x5" />
+            <param acdb_devices="DEVICE_HANDSET_MIC_CPE, DEVICE_HANDSET_TMIC_CPE, DEVICE_HEADSET_MIC_CPE" />
+            <!-- module_id, instance_id, param_id -->
+            <param load_sound_model_ids="0x00012C2E, 0x6, 0x00012C14" />
+            <param confidence_levels_ids="0x00012C2E, 0x6, 0x00012C28" />
+            <param detection_event_ids="0x00012C2E, 0x6, 0x00012B05" />
+            <param read_cmd_ids="0x00020013, 0x6, 0x00020015" />
+            <param read_rsp_ids="0x00020013, 0x6, 0x00020016" />
+            <param custom_config_ids="0x00012C2E, 0x6, 0x00012C2D" />
+            <param det_event_type_ids="0x00012C2E, 0x6, 0x00012C2C" />
+        </gcs_usecase>
+        <!-- Module and param ids with which the algorithm is integrated
+            in non-graphite firmware (note these must come after gcs params)
+            Extends flexibility to have different ids based on execution type.
+            valid execution_type values: only "ADSP" -->
+        <lsm_usecase>
+            <param capture_device="HANDSET" />
+            <!-- adm_cfg_profile should match with the one defined under adm_config -->
+            <!-- Set it to NONE if LSM directly connects to AFE -->
+            <param adm_cfg_profile="NONE" />
+            <!-- fluence_type: "FLUENCE_MIC", "FLUENCE_DMIC", "FLUENCE_TMIC"   -->
+            <!-- "FLUENCE_QMIC". Param value is valid when adm_cfg_profile -->
+            <!-- is FFECNS -->
+            <param fluence_type="NONE" />
+            <param execution_mode="ADSP" />
+            <param app_type="4" /> <!-- app type for MD used in ACDB -->
+            <param in_channels="1"/> <!-- Module input channels -->
+            <param load_sound_model_ids="0x00012C22, 0x0, 0x00012C14" />
+            <param unload_sound_model_ids="0x00012C22, 0x0, 0x00012C15" />
+            <param confidence_levels_ids="0x00012C22, 0x0, 0x00012C07" />
+            <param det_event_type_ids="0x00012C22, 0x0, 0x00012C2C" />
+            <param custom_config_ids="0x00012C22, 0x0, 0x00012C30" />
+        </lsm_usecase>
+        <lsm_usecase>
+            <param capture_device="HEADSET" />
+            <param adm_cfg_profile="NONE" />
+            <param fluence_type="NONE" />
+            <param execution_mode="ADSP" />
+            <param app_type="4" /> <!-- app type for MD used in ACDB -->
+            <param in_channels="1"/> <!-- Module input channels -->
+            <param load_sound_model_ids="0x00012C22, 0x0, 0x00012C14" />
+            <param unload_sound_model_ids="0x00012C22, 0x0, 0x00012C15" />
+            <param confidence_levels_ids="0x00012C22, 0x0, 0x00012C07" />
+            <param det_event_type_ids="0x00012C22, 0x0, 0x00012C2C" />
+            <param custom_config_ids="0x00012C22, 0x0, 0x00012C30" />
+        </lsm_usecase>
+
+        <!-- format: "ADPCM_packet" or "PCM_packet" !-->
+        <!--  kw_duration is in milli seconds. It is valid only for FTRT
+            transfer mode -->
+        <param capture_keyword="PCM_packet, FTRT, 1500" />
+        <param client_capture_read_delay="2000" />
+    </sound_model_config>
+
+    <sound_model_config> <!-- HOTWORD -->
+        <param vendor_uuid="7038ddc8-30f2-11e6-b0ac-40a8f03d3f15" />
+        <param execution_type="DYNAMIC" /> <!-- value: "WDSP" "ADSP" "DYNAMIC" -->
+        <param library="none" />
+        <param max_cpe_phrases="1" />
+        <param max_cpe_users="1" />
+        <param max_ape_phrases="1" />
+        <param max_ape_users="1" />
+        <!-- Profile specific data which the algorithm can support -->
+        <param sample_rate="16000" />
+        <param bit_width="16" />
+        <param out_channels="1"/> <!-- Module output channels -->
+        <!-- wdsp_fluence_type: fluence disabled: "NONE" -->
+        <!-- fluence enabled: "FLUENCE_DMIC", "FLUENCE_QMIC" -->
+        <param wdsp_fluence_type="NONE" />
+        <gcs_usecase>
+            <param uid="0x2" />
+            <param acdb_devices="DEVICE_HANDSET_MIC_CPE, DEVICE_HANDSET_TMIC_CPE, DEVICE_HEADSET_MIC_CPE" />
+            <param load_sound_model_ids="0x18000001, 0x3, 0x00012C14" />
+            <param confidence_levels_ids="0x18000001, 0x3, 0x00012C28" />
+            <param detection_event_ids="0x18000001, 0x3, 0x00012C29" />
+            <param read_cmd_ids="0x00020013, 0x3, 0x00020015" />
+            <param read_rsp_ids="0x00020013, 0x3, 0x00020016" />
+        </gcs_usecase>
+
+        <lsm_usecase>
+            <param capture_device="HANDSET" />
+            <!-- adm_cfg_profile should match with the one defined under adm_config -->
+            <!-- Set it to NONE if LSM directly connects to AFE -->
+            <param adm_cfg_profile="NONE" />
+            <!-- fluence_type: "FLUENCE_MIC", "FLUENCE_DMIC", "FLUENCE_TMIC"   -->
+            <!-- "FLUENCE_QMIC". Param value is valid when adm_cfg_profile -->
+            <!-- is FFECNS -->
+            <param fluence_type="NONE" />
+            <param execution_mode="ADSP" />
+            <param app_type="3" /> <!-- app type used in ACDB -->
+            <param in_channels="1"/> <!-- Module input channels -->
+            <param load_sound_model_ids="0x18000001, 0x0, 0x00012C14" />
+            <param unload_sound_model_ids="0x18000001, 0x0, 0x00012C15" />
+            <param confidence_levels_ids="0x18000001, 0x0, 0x00012C07" />
+            <param operation_mode_ids="0x18000001, 0x0, 0x00012C02" />
+            <param polling_enable_ids="0x18000001, 0x0, 0x00012C1B" />
+            <param custom_config_ids="0x18000001, 0x0, 0x00012C20" />
+        </lsm_usecase>
+        <lsm_usecase>
+            <param capture_device="HEADSET" />
+            <param adm_cfg_profile="NONE" />
+            <param fluence_type="NONE" />
+            <param execution_mode="ADSP" />
+            <param app_type="3" /> <!-- app type used in ACDB -->
+            <param in_channels="1"/> <!-- Module input channels -->
+            <param load_sound_model_ids="0x18000001, 0x0, 0x00012C14" />
+            <param unload_sound_model_ids="0x18000001, 0x0, 0x00012C15" />
+            <param confidence_levels_ids="0x18000001, 0x0, 0x00012C07" />
+            <param operation_mode_ids="0x18000001, 0x0, 0x00012C02" />
+            <param polling_enable_ids="0x18000001, 0x0, 0x00012C1B" />
+            <param custom_config_ids="0x18000001, 0x0, 0x00012C20" />
+        </lsm_usecase>
+
+        <!-- format: "ADPCM_packet" or "PCM_packet" !-->
+        <!-- transfer_mode: "FTRT" or "RT" -->
+        <!--  kw_duration is in milli seconds. It is valid only for FTRT
+            transfer mode -->
+        <param capture_keyword="PCM_raw, FTRT, 2000" />
+        <param client_capture_read_delay="2000" />
+    </sound_model_config>
+
+    <!-- Google Music Detection -->
+    <sound_model_config>
+        <param vendor_uuid="9f6ad62a-1f0b-11e7-87c5-40a8f03d3f15" />
+        <param execution_type="WDSP" /> <!-- value: "WDSP" "ADSP" "DYNAMIC" -->
+        <param library="none" />
+        <!-- fluence enabled: "FLUENCE_DMIC", "FLUENCE_QMIC" -->
+        <param wdsp_fluence_type="NONE" />
+        <gcs_usecase>
+            <param uid="0x6" />
+            <param acdb_devices="DEVICE_HANDSET_MIC_CPE" />
+            <param load_sound_model_ids="0x18000001, 0x4, 0x18000102" />
+            <param start_engine_ids="0x18000001, 0x4, 0x18000103" />
+            <param confidence_levels_ids="0x18000001, 0x4, 0x00012C28" />
+            <param detection_event_ids="0x18000001, 0x4, 0x00012C29" />
+            <param custom_config_ids="0x18000001, 0x4, 0x00012C20" />
+            <param read_cmd_ids="0x00020013, 0x7, 0x00020015" />
+            <param read_rsp_ids="0x00020013, 0x7, 0x00020016" />
+        </gcs_usecase>
+        <!--  kw_duration is in milli seconds. It is valid only for FTRT
+            transfer mode -->
+        <param capture_keyword="MULAW_raw, FTRT, 5000" />
+        <param client_capture_read_delay="2000" />
+    </sound_model_config>
+
+    <!-- Multiple adm_config tags can be listed, each with unique profile name. -->
+    <!-- app_type to match corresponding value from ACDB -->
+    <adm_config>
+        <param adm_cfg_profile="FFECNS" />
+        <param app_type="69947" />
+        <param sample_rate="16000" />
+        <param bit_width="16" />
+        <param out_channels="5"/>
+    </adm_config>
+
+    <!-- backend_type tag defines backend type for each device -->
+    <!-- Default value is assumed for devices that are not listed here -->
+    <backend_type>
+        <param DEVICE_HANDSET_MIC_ECPP_CPE="BACKEND_ECPP" />
+    </backend_type>
+</sound_trigger_platform_info>


### PR DESCRIPTION
This adds the Sound Trigger configuration for the SoMC SM8150
Kumano platform, imported from stock release 55.1.A.3.149.

Tested on SoMC SM8150 Kumano Griffin DSDS