### PR TITLE
fstab: Split into early and latemount, reserve 128M on /data

### DIFF
--- a/rootdir/vendor/etc/fstab.kumano
+++ b/rootdir/vendor/etc/fstab.kumano
@@ -2,9 +2,9 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,recoveryonly,slotselect
-/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly,slotselect
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
+/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults

--- a/rootdir/vendor/etc/fstab.kumano
+++ b/rootdir/vendor/etc/fstab.kumano
@@ -4,7 +4,7 @@
 
 /dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults


### PR DESCRIPTION
Makes things neater with the stage-separated mounting logic in Q and later.
