### PR TITLE
[KUMANO] Add CodeAurora Foundation Audio HAL advanced paths support

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -88,7 +88,17 @@ PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/audio_platform_info.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_platform_info.xml \
     $(SONY_ROOT)/vendor/etc/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml \
     $(SONY_ROOT)/vendor/etc/audio_policy_configuration_bluetooth_legacy_hal.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration_bluetooth_legacy_hal.xml \
-    $(SONY_ROOT)/vendor/etc/common_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/common_primary_audio_policy_configuration.xml
+    $(SONY_ROOT)/vendor/etc/common_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/common_primary_audio_policy_configuration.xml \
+
+# Audio - Routes variations and extensions between AOSP and CodeAurora Audio HAL features
+ifeq ($(TARGET_USES_AOSP_AUDIO_HAL),true)
+PRODUCT_COPY_FILES += \
+    $(SONY_ROOT)/vendor/etc/aosp_routes_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/routes_primary_audio_policy_configuration.xml
+else
+PRODUCT_COPY_FILES += \
+    $(SONY_ROOT)/vendor/etc/caf_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/caf_primary_audio_policy_configuration.xml \
+    $(SONY_ROOT)/vendor/etc/caf_routes_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/routes_primary_audio_policy_configuration.xml
+endif
 
 # Media
 PRODUCT_COPY_FILES += \

--- a/platform.mk
+++ b/platform.mk
@@ -97,7 +97,8 @@ PRODUCT_COPY_FILES += \
 else
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/caf_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/caf_primary_audio_policy_configuration.xml \
-    $(SONY_ROOT)/vendor/etc/caf_routes_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/routes_primary_audio_policy_configuration.xml
+    $(SONY_ROOT)/vendor/etc/caf_routes_primary_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/routes_primary_audio_policy_configuration.xml \
+    $(SONY_ROOT)/vendor/etc/audio_io_policy.conf:$(TARGET_COPY_OUT_VENDOR)/etc/audio_io_policy.conf
 endif
 
 # Media

--- a/rootdir/vendor/etc/aosp_routes_primary_audio_policy_configuration.xml
+++ b/rootdir/vendor/etc/aosp_routes_primary_audio_policy_configuration.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- This file contains audio routes used by the AOSP Audio HAL
+     for Qualcomm SoCs. -->
+<module>
+    <!-- route declaration, i.e. list all available sources for a given sink -->
+    <routes>
+        <route type="mix" sink="Earpiece"
+               sources="primary output,raw,deep_buffer"/>
+        <route type="mix" sink="Speaker"
+               sources="primary output,raw,deep_buffer,compressed_offload"/>
+        <route type="mix" sink="Wired Headset"
+               sources="primary output,raw,deep_buffer,compressed_offload"/>
+        <route type="mix" sink="Wired Headphones"
+               sources="primary output,raw,deep_buffer,compressed_offload"/>
+        <route type="mix" sink="Line Out"
+               sources="primary output,raw,deep_buffer,compressed_offload"/>
+        <route type="mix" sink="BT SCO"
+               sources="primary output,raw,deep_buffer"/>
+        <route type="mix" sink="BT SCO Headset"
+               sources="primary output,raw,deep_buffer"/>
+        <route type="mix" sink="BT SCO Car Kit"
+               sources="primary output,raw,deep_buffer"/>
+        <route type="mix" sink="Telephony Tx"
+               sources="voice_tx"/>
+        <route type="mix" sink="primary input"
+               sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic,BT SCO Headset Mic"/>
+        <route type="mix" sink="fast input"
+               sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic,BT SCO Headset Mic"/>
+        <route type="mix" sink="voice_rx"
+               sources="Telephony Rx"/>
+    </routes>
+</module>

--- a/rootdir/vendor/etc/audio_io_policy.conf
+++ b/rootdir/vendor/etc/audio_io_policy.conf
@@ -1,0 +1,112 @@
+# List of profiles for the output device session where stream is routed.
+# A stream opened with the inputs attributes which match the "flags" and
+# "formats" as specified in the profile is routed to a device at
+# sample rate specified under "sampling_rates" and bit width under
+# "bit_width" and the topology extracted from the acdb data against
+# the "app_type".
+#
+# the flags and formats are specified using the strings corresponding to
+# enums in audio.h and audio_policy.h. They are concatenated with "|"
+# without space or "\n".
+# the flags and formats should match the ones in "audio_policy.conf"
+
+outputs {
+  default {
+    flags AUDIO_OUTPUT_FLAG_PRIMARY
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 48000
+    bit_width 16
+    app_type 69937
+  }
+  proaudio {
+    flags AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 48000
+    bit_width 16
+    app_type 69943
+  }
+  voip_rx {
+    flags AUDIO_OUTPUT_FLAG_VOIP_RX|AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 8000|16000|32000|48000
+    bit_width 16
+    app_type 69946
+  }
+  deep_buffer {
+    flags AUDIO_OUTPUT_FLAG_DEEP_BUFFER
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 48000
+    bit_width 16
+    app_type 69936
+  }
+  direct_pcm_16 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_16_BIT|AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_8_24_BIT|AUDIO_FORMAT_PCM_32_BIT
+    sampling_rates 44100|48000|96000|192000
+    bit_width 16
+    app_type 69936
+  }
+  direct_pcm_24 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_8_24_BIT|AUDIO_FORMAT_PCM_32_BIT
+    sampling_rates 44100|48000|96000|192000|384000
+    bit_width 24
+    app_type 69940
+  }
+  direct_pcm_32 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_32_BIT
+    sampling_rates 44100|48000|96000|192000|384000
+    bit_width 32
+    app_type 69942
+  }
+  compress_passthrough {
+    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING|AUDIO_OUTPUT_FLAG_COMPRESS_PASSTHROUGH
+    formats AUDIO_FORMAT_DTS|AUDIO_FORMAT_DTS_HD|AUDIO_FORMAT_DSD
+    sampling_rates 32000|44100|48000|88200|96000|176400|192000|352800
+    bit_width 16
+    app_type 69941
+  }
+  compress_offload_16 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING
+    formats AUDIO_FORMAT_MP3|AUDIO_FORMAT_PCM_16_BIT_OFFLOAD|AUDIO_FORMAT_PCM_24_BIT_OFFLOAD|AUDIO_FORMAT_FLAC|AUDIO_FORMAT_ALAC|AUDIO_FORMAT_APE|AUDIO_FORMAT_AAC_LC|AUDIO_FORMAT_AAC_HE_V1|AUDIO_FORMAT_AAC_HE_V2|AUDIO_FORMAT_WMA|AUDIO_FORMAT_WMA_PRO|AUDIO_FORMAT_VORBIS|AUDIO_FORMAT_AAC_ADTS_LC|AUDIO_FORMAT_AAC_ADTS_HE_V1|AUDIO_FORMAT_AAC_ADTS_HE_V2
+    sampling_rates 44100|48000
+    bit_width 16
+    app_type 69936
+  }
+  compress_offload_24 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING
+    formats AUDIO_FORMAT_PCM_24_BIT_OFFLOAD|AUDIO_FORMAT_FLAC|AUDIO_FORMAT_ALAC|AUDIO_FORMAT_APE|AUDIO_FORMAT_VORBIS|AUDIO_FORMAT_WMA|AUDIO_FORMAT_WMA_PRO
+    sampling_rates 44100|48000|96000|192000
+    bit_width 24
+    app_type 69940
+  }
+}
+
+inputs {
+  primary {
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 8000|16000|32000|44100|48000|88200|96000|176400|192000
+    bit_width 16
+    app_type 69938
+  }
+  record_24bit {
+    formats AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_24_BIT
+    sampling_rates 44100|48000|88200|96000|176400|192000
+    bit_width 24
+    app_type 69948
+  }
+  record_32bit {
+    formats AUDIO_FORMAT_PCM_32_BIT|AUDIO_FORMAT_PCM_FLOAT
+    sampling_rates 44100|48000|88200|96000|176400|192000
+    bit_width 32
+    app_type 69949
+  }
+  record_unprocessed {
+    profile record_unprocessed
+    formats AUDIO_FORMAT_PCM_24_BIT_PACKED
+    sampling_rates 16000|48000
+    bit_width 24
+    app_type 69942
+  }
+}

--- a/rootdir/vendor/etc/audio_policy_configuration.xml
+++ b/rootdir/vendor/etc/audio_policy_configuration.xml
@@ -46,6 +46,11 @@
         <!-- Primary Audio HAL -->
         <module name="primary" halVersion="2.0">
             <xi:include href="common_primary_audio_policy_configuration.xml" xpointer="xpointer(/module/*)" />
+            <xi:include href="caf_primary_audio_policy_configuration.xml" xpointer="xpointer(/module/*)">
+                <!-- Fall back to .. nothing: if this file doesn't exist we are not extending the AOSP policy. -->
+                <xi:fallback />
+            </xi:include>
+            <xi:include href="routes_primary_audio_policy_configuration.xml" xpointer="xpointer(/module/*)" />
         </module>
 
         <!-- A2dp Input Audio HAL -->

--- a/rootdir/vendor/etc/caf_primary_audio_policy_configuration.xml
+++ b/rootdir/vendor/etc/caf_primary_audio_policy_configuration.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- This file contains entries understood and used by the 
+     CodeAurora-based "primary" Audio HAL, extending the ones
+     used by the AOSP variant.
+-->
+<module>
+    <mixPorts>
+        <mixPort name="mmap_no_irq_out" role="source" flags="AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_MMAP_NOIRQ">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+        </mixPort>
+        <mixPort name="hifi_playback" role="source" />
+        <mixPort name="compress_passthrough" role="source"
+                 flags="AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING">
+            <profile name="" format="dynamic"
+                     samplingRates="dynamic" channelMasks="dynamic"/>
+        </mixPort>
+        <mixPort name="dsd_compress_passthrough" role="source"
+                 flags="AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING">
+            <profile name="" format="AUDIO_FORMAT_DSD"
+                     samplingRates="2822400,5644800"
+                     channelMasks="AUDIO_CHANNEL_OUT_STEREO,AUDIO_CHANNEL_OUT_MONO"/>
+        </mixPort>
+        <mixPort name="voip_rx" role="source" flags="AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_VOIP_RX">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="8000,16000,32000,48000" channelMasks="AUDIO_CHANNEL_OUT_MONO"/>
+        </mixPort>
+        <mixPort name="incall_music_uplink" role="source"
+                        flags="AUDIO_OUTPUT_FLAG_INCALL_MUSIC">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="8000,16000,48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+        </mixPort>
+
+        <mixPort name="voip_tx" role="sink"
+         flags="AUDIO_INPUT_FLAG_VOIP_TX">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+             samplingRates="8000,16000,32000,48000" channelMasks="AUDIO_CHANNEL_IN_MONO"/>
+        </mixPort>
+        <mixPort name="usb_surround_sound" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+             samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000,88200,96000,176400,192000"
+             channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO,AUDIO_CHANNEL_IN_FRONT_BACK,AUDIO_CHANNEL_INDEX_MASK_3,AUDIO_CHANNEL_INDEX_MASK_4,AUDIO_CHANNEL_IN_5POINT1,AUDIO_CHANNEL_INDEX_MASK_6,AUDIO_CHANNEL_IN_7POINT1,AUDIO_CHANNEL_INDEX_MASK_8"/>
+            <profile name="" format="AUDIO_FORMAT_PCM_32_BIT"
+             samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000,88200,96000,176400,192000"
+             channelMasks="AUDIO_CHANNEL_IN_5POINT1,AUDIO_CHANNEL_INDEX_MASK_6,AUDIO_CHANNEL_IN_7POINT1,AUDIO_CHANNEL_INDEX_MASK_8"/>
+            <profile name="" format="AUDIO_FORMAT_PCM_FLOAT"
+             samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000,88200,96000,176400,192000"
+             channelMasks="AUDIO_CHANNEL_IN_5POINT1,AUDIO_CHANNEL_INDEX_MASK_6,AUDIO_CHANNEL_IN_7POINT1,AUDIO_CHANNEL_INDEX_MASK_8"/>
+        </mixPort>
+        <mixPort name="record_24" role="sink" maxOpenCount="2" maxActiveCount="2">
+            <profile name="" format="AUDIO_FORMAT_PCM_24_BIT_PACKED"
+             samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000,96000,192000"
+             channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO,AUDIO_CHANNEL_IN_FRONT_BACK,AUDIO_CHANNEL_INDEX_MASK_3,AUDIO_CHANNEL_INDEX_MASK_4"/>
+            <profile name="" format="AUDIO_FORMAT_PCM_8_24_BIT"
+             samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000,96000,192000"
+             channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO,AUDIO_CHANNEL_IN_FRONT_BACK,AUDIO_CHANNEL_INDEX_MASK_3,AUDIO_CHANNEL_INDEX_MASK_4"/>
+            <profile name="" format="AUDIO_FORMAT_PCM_FLOAT"
+             samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000,96000,192000"
+             channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO,AUDIO_CHANNEL_IN_FRONT_BACK,AUDIO_CHANNEL_INDEX_MASK_3,AUDIO_CHANNEL_INDEX_MASK_4"/>
+        </mixPort>
+        <mixPort name="mmap_no_irq_in" role="sink" flags="AUDIO_INPUT_FLAG_MMAP_NOIRQ">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+             samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000"
+             channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO,AUDIO_CHANNEL_IN_FRONT_BACK,AUDIO_CHANNEL_INDEX_MASK_3"/>
+        </mixPort>
+        <mixPort name="hifi_input" role="sink" />
+    </mixPorts>
+    <devicePorts>
+        <!-- Output devices additional declaration, i.e. Sink DEVICE PORT -->
+		<devicePort tagName="HDMI" type="AUDIO_DEVICE_OUT_AUX_DIGITAL" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                     samplingRates="8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,128000,176400,192000"
+                     channelMasks="dynamic"/>
+        </devicePort>
+        <devicePort tagName="Proxy" type="AUDIO_DEVICE_OUT_PROXY" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+                 samplingRates="8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,128000,176400,192000"
+                 channelMasks="dynamic"/>
+        </devicePort>
+        <devicePort tagName="USB Device Out" type="AUDIO_DEVICE_OUT_USB_DEVICE" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+             samplingRates="44100,48000,64000,88200,96000,128000,176400,192000" channelMasks="dynamic"/>
+        </devicePort>
+        <devicePort tagName="USB Headset Out" type="AUDIO_DEVICE_OUT_USB_HEADSET" role="sink">
+            <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
+             samplingRates="44100,48000,64000,88200,96000,128000,176400,192000" channelMasks="dynamic"/>
+        </devicePort>
+
+        <devicePort tagName="USB Device In" type="AUDIO_DEVICE_IN_USB_DEVICE" role="source"/>
+        <devicePort tagName="USB Headset In" type="AUDIO_DEVICE_IN_USB_HEADSET" role="source"/>
+    </devicePorts>
+</module>

--- a/rootdir/vendor/etc/caf_routes_primary_audio_policy_configuration.xml
+++ b/rootdir/vendor/etc/caf_routes_primary_audio_policy_configuration.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- This file contains audio routes used by the AOSP Audio HAL
+     for Qualcomm SoCs.
+-->
+<module>
+    <!-- route declaration, i.e. list all available sources for a given sink -->
+    <routes>
+        <route type="mix" sink="Earpiece"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx,mmap_no_irq_out"/>
+        <route type="mix" sink="Speaker"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx,mmap_no_irq_out"/>
+        <route type="mix" sink="Wired Headset"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,dsd_compress_passthrough,voip_rx,mmap_no_irq_out"/>
+        <route type="mix" sink="Wired Headphones"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,dsd_compress_passthrough,voip_rx,mmap_no_irq_out"/>
+        <route type="mix" sink="Line"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,dsd_compress_passthrough,voip_rx,mmap_no_irq_out"/>
+        <route type="mix" sink="HDMI"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload"/>
+        <route type="mix" sink="Proxy"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload"/>
+        <route type="mix" sink="BT SCO"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+        <route type="mix" sink="BT SCO Headset"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+        <route type="mix" sink="BT SCO Car Kit"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+        <route type="mix" sink="USB Device Out"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx,mmap_no_irq_out,hifi_playback"/>
+        <route type="mix" sink="USB Headset Out"
+               sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx,mmap_no_irq_out,hifi_playback"/>
+        <route type="mix" sink="Telephony Tx"
+               sources="voice_tx,incall_music_uplink"/>
+        <route type="mix" sink="voice_rx"
+               sources="Telephony Rx"/>
+        <route type="mix" sink="primary input"
+               sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic,BT SCO Headset Mic,FM Tuner,USB Device In,USB Headset In,Telephony Rx"/>
+        <route type="mix" sink="voip_tx"
+               sources="Built-In Mic,Built-In Back Mic,BT SCO Headset Mic,USB Device In,USB Headset In"/>
+        <route type="mix" sink="usb_surround_sound"
+               sources="USB Device In,USB Headset In"/>
+        <route type="mix" sink="record_24"
+               sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic"/>
+        <route type="mix" sink="mmap_no_irq_in"
+               sources="Built-In Mic,Built-In Back Mic,Wired Headset Mic,USB Device In,USB Headset In"/>
+        <route type="mix" sink="BT A2DP Out"
+               sources="primary output,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+        <route type="mix" sink="BT A2DP Headphones"
+               sources="primary output,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+        <route type="mix" sink="BT A2DP Speaker"
+               sources="primary output,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
+        <route type="mix" sink="hifi_input" sources="USB Device In,USB Headset In" />
+    </routes>
+</module>


### PR DESCRIPTION
This patchset adds support for the CodeAurora Foundation (CAF) Audio
HAL extended paths and offloading, while still retaining compatibility
with the Audio HAL for Qualcomm devices provided in the Google's AOSP
repositories.

This patchset has to be *and will be* replicated on all platforms whenever
testing gets complete on each.

Tested on Sony SM8150 Kumano Griffin DSDS.
P.S.: It's amazing! 