### PR TITLE
[KUMANO] [MASTER] vendor: init: kumano-power: Cleanup and fix power parameters

### DIFF
--- a/rootdir/vendor/etc/init/init.kumano.pwr.rc
+++ b/rootdir/vendor/etc/init/init.kumano.pwr.rc
@@ -103,94 +103,81 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpu6/online 1
     write /sys/devices/system/cpu/cpu7/online 1
 
-    # Disable CPU Retention
-    write /sys/module/lpm_levels/L3/cpu0/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/cpu1/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/cpu2/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/cpu3/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/cpu4/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/cpu5/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/cpu6/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/cpu7/ret/idle_enabled N
-    write /sys/module/lpm_levels/L3/l3-dyn-ret/idle_enabled N
+    # Enable bus-dcvs
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/governor bw_hwmon
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/polling_interval 40
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/mbps_zones "2288 4577 7110 9155 12298 14236 15258"
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/sample_ms 4
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/io_percent 50
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/hist_memory 20
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/hyst_length 10
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/down_thres 30
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/guard_band_mbps 0
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/up_scale 250
+    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/soc:qcom,cpu-cpu-llcc-bw/bw_hwmon/idle_mbps 1600
 
-    # Turn on sleep modes.
-    write /sys/module/lpm_levels/parameters/sleep_disabled 0
-
-	# Enable bus-dcvs
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/governor "bw_hwmon"
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/polling_interval 40
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/mbps_zones "2288 4577 7110 9155 12298 14236 15258"
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/sample_ms 4
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/io_percent 50
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/hist_memory 20
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/hyst_length 10
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/down_thres 30
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/guard_band_mbps 0
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/up_scale 250
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/bw_hwmon/idle_mbps 1600
-    write /sys/devices/platform/soc/soc:qcom,cpu-cpu-llcc-bw/devfreq/*cpu-cpu-llcc-bw/max_freq 14236
-
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/governor "bw_hwmon"
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/polling_interval 40
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/mbps_zones "1720 2929 3879 5931 6881 7980"
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/sample_ms 4
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/io_percent 80
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/hist_memory 20
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/hyst_length 10
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/down_thres 30
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/guard_band_mbps 0
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/up_scale 250
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/bw_hwmon/idle_mbps 1600
-    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/*cpu-llcc-ddr-bw/max_freq 6881
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/governor bw_hwmon
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/polling_interval 40
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/mbps_zones "1720 2929 3879 5931 6881 7980"
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/sample_ms 4
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/io_percent 80
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/hist_memory 20
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/hyst_length 10
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/down_thres 30
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/guard_band_mbps 0
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/up_scale 250
+    write /sys/devices/platform/soc/soc:qcom,cpu-llcc-ddr-bw/devfreq/soc:qcom,cpu-llcc-ddr-bw/bw_hwmon/idle_mbps 1600
 
     write /sys/devices/virtual/npu/msm_npu/pwr 1
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/governor  "bw_hwmon"
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/polling_interval 40
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/mbps_zones "1720 2929 3879 5931 6881 7980"
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/sample_ms 4
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/io_percent 80
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/hist_memory 20
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/hyst_length 6
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/down_thres 30
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/guard_band_mbps 0
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/up_scale 250
-    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/*npu-npu-ddr-bw/bw_hwmon/idle_mbps 0
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/governor bw_hwmon
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/polling_interval 40
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/mbps_zones "1720 2929 3879 5931 6881 7980"
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/sample_ms 4
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/io_percent 80
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/hist_memory 20
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/hyst_length 6
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/down_thres 30
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/guard_band_mbps 0
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/up_scale 250
+    write /sys/devices/platform/soc/soc:qcom,npu-npu-ddr-bw/devfreq/soc:qcom,npu-npu-ddr-bw/bw_hwmon/idle_mbps 0
     write /sys/devices/virtual/npu/msm_npu/pwr 0
 
     #Enable mem_latency governor for L3, LLCC, and DDR scaling
+    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-llcc-lat/devfreq/soc:qcom,cpu0-cpu-llcc-lat/governor mem_latency
+    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-llcc-lat/devfreq/soc:qcom,cpu0-cpu-llcc-lat/polling_interval 10
+    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-llcc-lat/devfreq/soc:qcom,cpu0-cpu-llcc-lat/mem_latency/ratio_ceil 400
 
-    # Silver Cores  
-    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-l3-lat/devfreq/*cpu*-lat/governor "mem_latency"
-    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-l3-lat/devfreq/*cpu*-lat/polling_interval 10
-    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-l3-lat/devfreq/*cpu*-lat/mem_latency/ratio_ceil 400
+    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-l3-lat/devfreq/soc:qcom,cpu0-cpu-l3-lat/governor mem_latency
+    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-l3-lat/devfreq/soc:qcom,cpu0-cpu-l3-lat/polling_interval 10
+    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-l3-lat/devfreq/soc:qcom,cpu0-cpu-l3-lat/mem_latency/ratio_ceil 400
 
-    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-llcc-lat/devfreq/*cpu*-lat/governor "mem_latency"
-    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-llcc-lat/devfreq/*cpu*-lat/polling_interval 10
-    write /sys/devices/platform/soc/soc:qcom,cpu0-cpu-llcc-lat/devfreq/*cpu*-lat/mem_latency/ratio_ceil 400
+    write /sys/devices/platform/soc/soc:qcom,cpu0-llcc-ddr-lat/devfreq/soc:qcom,cpu0-llcc-ddr-lat/governor mem_latency
+    write /sys/devices/platform/soc/soc:qcom,cpu0-llcc-ddr-lat/devfreq/soc:qcom,cpu0-llcc-ddr-lat/polling_interval 10
+    write /sys/devices/platform/soc/soc:qcom,cpu0-llcc-ddr-lat/devfreq/soc:qcom,cpu0-llcc-ddr-lat/mem_latency/ratio_ceil 400
 
-    write /sys/devices/platform/soc/soc:qcom,cpu0-llcc-ddr-lat/devfreq/*cpu*-lat/governor "mem_latency"
-    write /sys/devices/platform/soc/soc:qcom,cpu0-llcc-ddr-lat/devfreq/*cpu*-lat/polling_interval 10
-    write /sys/devices/platform/soc/soc:qcom,cpu0-llcc-ddr-lat/devfreq/*cpu*-lat/mem_latency/ratio_ceil 400
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-llcc-lat/devfreq/soc:qcom,cpu4-cpu-llcc-lat/governor mem_latency
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-llcc-lat/devfreq/soc:qcom,cpu4-cpu-llcc-lat/polling_interval 10
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-llcc-lat/devfreq/soc:qcom,cpu4-cpu-llcc-lat/mem_latency/ratio_ceil 400
 
-    # Gold Cores
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-l3-lat/devfreq/*cpu*-lat/governor "mem_latency"
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-l3-lat/devfreq/*cpu*-lat/polling_interval 10
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-l3-lat/devfreq/*cpu*-lat/mem_latency/ratio_ceil 4000
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-l3-lat/devfreq/soc:qcom,cpu4-cpu-l3-lat/governor mem_latency
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-l3-lat/devfreq/soc:qcom,cpu4-cpu-l3-lat/polling_interval 10
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-l3-lat/devfreq/soc:qcom,cpu4-cpu-l3-lat/mem_latency/ratio_ceil 4000
 
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-llcc-lat/devfreq/*cpu*-lat/governor "mem_latency"
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-llcc-lat/devfreq/*cpu*-lat/polling_interval 10
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-llcc-lat/devfreq/*cpu*-lat/mem_latency/ratio_ceil 4000
+    write /sys/devices/platform/soc/soc:qcom,cpu7-cpu-l3-lat/devfreq/soc:qcom,cpu7-cpu-l3-lat/governor mem_latency
+    write /sys/devices/platform/soc/soc:qcom,cpu7-cpu-l3-lat/devfreq/soc:qcom,cpu7-cpu-l3-lat/polling_interval 10
+    write /sys/devices/platform/soc/soc:qcom,cpu7-cpu-l3-lat/devfreq/soc:qcom,cpu7-cpu-l3-lat/mem_latency/ratio_ceil 20000
 
-    write /sys/devices/platform/soc/soc:qcom,cpu4-llcc-ddr-lat/devfreq/*cpu*-lat/governor "mem_latency"
-    write /sys/devices/platform/soc/soc:qcom,cpu4-llcc-ddr-lat/devfreq/*cpu*-lat/polling_interval 10
-    write /sys/devices/platform/soc/soc:qcom,cpu4-llcc-ddr-lat/devfreq/*cpu*-lat/mem_latency/ratio_ceil 4000
+    write /sys/devices/platform/soc/soc:qcom,cpu4-llcc-ddr-lat/devfreq/soc:qcom,cpu4-llcc-ddr-lat/governor mem_latency
+    write /sys/devices/platform/soc/soc:qcom,cpu4-llcc-ddr-lat/devfreq/soc:qcom,cpu4-llcc-ddr-lat/polling_interval 10
+    write /sys/devices/platform/soc/soc:qcom,cpu4-llcc-ddr-lat/devfreq/soc:qcom,cpu4-llcc-ddr-lat/mem_latency/ratio_ceil 400
 
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-ddr-latfloor/devfreq/*cpu-ddr-latfloor*/governor "compute"
-    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-ddr-latfloor/devfreq/*cpu-ddr-latfloor*/polling_interval 10
+    #Enable userspace governor for L3 cdsp nodes
+    write /sys/devices/platform/soc/soc:qcom,cdsp-cdsp-l3-lat/devfreq/soc:qcom,cdsp-cdsp-l3-lat/governor cdspl3
 
-    #Prime L3 ratio ceil
-    write /sys/devices/platform/soc/soc:qcom,cpu7-cpu-l3-lat/devfreq/*cpu7-cpu-l3-lat/mem_latency/ratio_ceil 20000
+    #Enable compute governor for gold latfloor
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-ddr-latfloor/devfreq/soc:qcom,cpu4-cpu-ddr-latfloor/governor compute
+    write /sys/devices/platform/soc/soc:qcom,cpu4-cpu-ddr-latfloor/devfreq/soc:qcom,cpu4-cpu-ddr-latfloor/polling_interval 10
 
+    chown system system /sys/class/devfreq/soc:qcom,l3-cdsp/userspace/set_freq
 
     write /sys/module/lpm_levels/parameters/sleep_disabled 0


### PR DESCRIPTION
This platform had "totally" bad configuration for power management:
first of all, we were trying to disable retention on L3, but...
surprise! the kernel does not even support it!

Then, there was a major issue about the bus-dcvs and entire
devfreq configuration for basically all of the internal devices:
we were * for some reason * trying to write by using wildcards,
which is not supported in Android init scripts: that was messing
up the entire platform sleep, locking the RPMh in active state.