### PR TITLE
[KUMANO] [URGENT] vendor: caf: audio_policy_configuration: Remove FAST from raw

### DIFF
--- a/rootdir/vendor/etc/caf_common_primary_audio_policy_configuration.xml
+++ b/rootdir/vendor/etc/caf_common_primary_audio_policy_configuration.xml
@@ -20,7 +20,7 @@
                      channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         </mixPort>
         <mixPort name="raw" role="source"
-                 flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW">
+                 flags="AUDIO_OUTPUT_FLAG_RAW">
             <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                      samplingRates="48000"
                      channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>


### PR DESCRIPTION
The AUDIO_OUTPUT_FLAG_FAST on RAW seems to be activating
the ULL path, which doesn't work, on this platform.
Please note that ULL here means PROAUDIO, which is way less
latency than the old ultra low latency, and it's also using more CPU
for very little reasons: this is a phone.

This commit may be temporary: if we can activate this mode for
professional grade audio (using phone as an amp for musical
instruments and such -- for some reason) then we will reintroduce
this thing.

For now, having FAST in leads to many sound breakages, especially
in Android games nor anything else requesting RAW output.

------------------------

This PR fixes DSP lockups and loss of audio on the Kumano platform.
Tested on SM8150 Kumano Griffin DSDS.