### PR TITLE
[KUMANO] [Q-MR1] Re-Enable Ultra Low Latency path

### DIFF
--- a/rootdir/vendor/etc/caf_common_primary_audio_policy_configuration.xml
+++ b/rootdir/vendor/etc/caf_common_primary_audio_policy_configuration.xml
@@ -20,7 +20,7 @@
                      channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
         </mixPort>
         <mixPort name="raw" role="source"
-                 flags="AUDIO_OUTPUT_FLAG_RAW">
+                 flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW">
             <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                      samplingRates="48000"
                      channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>


### PR DESCRIPTION
The ULL path was fixed in Griffin and Bahamut mixer_paths: it is now
safe to re-enable it platform-wide.