### PR TITLE
[KUMANO] [Q/R] [1/2] Drop unsupported NFC eSE

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -322,11 +322,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.qcom.bluetooth.soc=cherokee
 
-# NFC eSE Support
-PRODUCT_PACKAGES += \
-    SecureElement \
-    android.hardware.secure_element@1.1-service
-
 # Audio - Android System
 PRODUCT_PROPERTY_OVERRIDES += \
     aaudio.mmap_policy=2 \

--- a/platform.mk
+++ b/platform.mk
@@ -137,11 +137,6 @@ PRODUCT_COPY_FILES += \
      frameworks/native/data/etc/android.hardware.sensor.stepcounter.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.sensor.stepcounter.xml \
      frameworks/native/data/etc/android.hardware.sensor.stepdetector.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.sensor.stepdetector.xml
 
-# NFC eSE Permissions
-PRODUCT_COPY_FILES += \
-     frameworks/native/data/etc/android.hardware.nfc.uicc.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.nfc.uicc.xml \
-     frameworks/native/data/etc/android.hardware.nfc.ese.xml:$(TARGET_OUT_COPY_VENDOR)/etc/permissions/android.hardware.nfc.ese.xml
-
 # Audio
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/sound_trigger_platform_info.xml:$(TARGET_COPY_OUT_VENDOR)/etc/sound_trigger_platform_info.xml \


### PR DESCRIPTION
Kumano does not have a Secure Element reader in the NFC. UICC host card emulation is supported by all our platforms and will be moved to common. Unnecessary `SecureElement` app dependencies are removed as well.