### PR TITLE
[master] kumano: fstab: Enable inlinecrypt flag for data

### DIFF
--- a/rootdir/vendor/etc/fstab.kumano
+++ b/rootdir/vendor/etc/fstab.kumano
@@ -4,7 +4,7 @@
 
 /dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic,inlinecrypt  latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults


### PR DESCRIPTION
On google msm-kernel-4.14 stable branch, these configs is enabled and used by Android 11.
```
CONFIG_FS_ENCRYPTION_INLINE_CRYPT=y
CONFIG_FS_VERITY=y
CONFIG_FS_VERITY_BUILTIN_SIGNATURES=y
```
Since we already upgraded to stock 11, new bootloader require this feature.
We need this flag to decrypt data partition on CAF LA.UM.9.12 kernel with latest bootloader, or decryption will be failed.