### PR TITLE
[KUMANO] [Q/R] sepolicy: Use root_block_device for sda instead of gpt_block_device

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -5,7 +5,7 @@
 /dev/block/mmcblk0p1                                           u:object_r:sd_block_device:s0
 
 # Block device holding the GPT, where the A/B attributes are stored.
-/dev/block/sda                                                 u:object_r:gpt_block_device:s0
+/dev/block/sda                                                 u:object_r:root_block_device:s0
 
 # Block devices for the drive that holds the xbl_a and xbl_b partitions.
 /dev/block/sd[bc]1?                                            u:object_r:xbl_block_device:s0


### PR DESCRIPTION
`gpt_block_device` is a custom SODP invention while AOSP already defines `root_block_device` for exactly this purpose; that is already used for `mmcblk0` on MMC platforms.