### PR TITLE
[KUMANO] [master] Revert "kumano: fstab: Enable inlinecrypt flag for data"

### DIFF
--- a/rootdir/vendor/etc/fstab.kumano
+++ b/rootdir/vendor/etc/fstab.kumano
@@ -4,7 +4,7 @@
 
 /dev/block/bootdevice/by-name/system       /            ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,slotselect,first_stage_mount
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic,inlinecrypt  latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp          /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim,slotselect
 /dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults


### PR DESCRIPTION
Similar to https://github.com/sonyxperiadev/device-sony-seine/pull/32

This reverts commit 8253144257fa9316e4af22ad831e226ae284a08c.

Kumano is not on CAF LA.UM.9.12 and likely won't end up there anyway.
This patch prevents properly working devices from booting with kernel
4.14 (snippet from seine):

    E EXT4-fs (mmcblk0p86): Unrecognized mount option "inlinecrypt" or missing value
    I init    : [libfs_mgr]__mount(source=/dev/block/bootdevice/by-name/userdata,target=/data,type=ext4)=-1: Invalid argument

Reverting this patch restores normal device functionality.