### PR TITLE
[KUMANO] [R-MR1] vendor: camx: Add flags for stabler autofocus and faster face-detection

### DIFF
--- a/rootdir/vendor/etc/camera/camxoverridesettings.txt
+++ b/rootdir/vendor/etc/camera/camxoverridesettings.txt
@@ -6,3 +6,17 @@ systemLogEnable=FALSE
 maxHalRequests=9
 numPCRsBeforeStreamOn=1
 preFlashMaxFrameWaitLimitAF=45
+numMetadataResults=1
+waitAllResultsTimeout=20
+
+enableDualIFE=TRUE
+dualBHistSupport=TRUE
+overrideEnableMFNR=1
+enableOfflineNoiseReprocess=1
+enableCHIPartialData=CHIPartialDataSeparate
+enableTBMChiFence=TRUE
+
+enableFDStreamInRealTime=TRUE
+enableSMDetection=TRUE
+enableCTDetection=TRUE
+


### PR DESCRIPTION
These flags are providing a stabler autofocus by disabling partial
metadata and sets face detection in real-time, therefore improving
FD latency.