### PR TITLE
[S-mr1] mediacodec: Import system_properties from CAF.

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -151,7 +151,8 @@ endif
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/vendor/etc/media_codecs.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs.xml \
     $(SONY_ROOT)/vendor/etc/media_codecs_performance.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_performance.xml \
-    $(SONY_ROOT)/vendor/etc/media_profiles_V1_0.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_profiles_V1_0.xml
+    $(SONY_ROOT)/vendor/etc/media_profiles_V1_0.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_profiles_V1_0.xml \
+    $(SONY_ROOT)/vendor/etc/system_properties.xml:$(TARGET_COPY_OUT_VENDOR)/etc/system_properties.xml
 
 # Qualcom WiFi Overlay
 PRODUCT_COPY_FILES += \

--- a/rootdir/vendor/etc/system_properties.xml
+++ b/rootdir/vendor/etc/system_properties.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Copyright (c) 2018 - 2019, The Linux Foundation. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of The Linux Foundation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<configs>
+        <property name="vidc_dec_log_in" value="0"/>
+        <property name="vidc_dec_log_out" value="0"/>
+        <property name="vidc_enc_log_in" value="0"/>
+        <property name="vidc_enc_log_out" value="0"/>
+        <property name="vidc_enc_csc_custom_matrix" value="0"/>
+        <property name="vidc_perf_control_enable" value="0"/>
+        <!-- Buffer size : internal : 200 MB (200 X 1), output : 200 MB (12.5 X 16) -->
+        <property name="vidc_dec_sec_prefetch_size_internal" value="209715200"/>
+        <property name="vidc_dec_sec_prefetch_size_output" value="13434880"/>
+        <!-- Bitmask for arb mode: 1: AVC, 2: HEVC, 4: MPEG2 -->
+        <property name="vidc_dec_arb_mode_override" value="7"/>
+        <!-- Bitmask for linear color: 1: 8-bit, 2: 10-bit -->
+        <property name="vidc_enc_linear_color_format" value="0"/>
+        <property name="vidc_enc_bitrate_savings_enable" value="1"/>
+</configs>


### PR DESCRIPTION
Imported from vendor-qcom-opensource-media as of 182649923d3813e2e539a0e36d83b3e70dcfcc4a:
https://github.com/sonyxperiadev/vendor-qcom-opensource-media/tree/182649923d3813e2e539a0e36d83b3e70dcfcc4a

Required for https://github.com/sonyxperiadev/local_manifests/pull/127 on S.